### PR TITLE
Rmac/font weight mapping

### DIFF
--- a/docs/src/specs/controls.json
+++ b/docs/src/specs/controls.json
@@ -911,7 +911,7 @@
         "syntax": "normal | italic | oblique"
       },
       "font-weight": {
-        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
+        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
       },
       "font-stretch": {
         "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded"
@@ -1149,7 +1149,7 @@
         "syntax": "normal | italic | oblique"
       },
       "font-weight": {
-        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
+        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
       },
       "font-stretch": {
         "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded"
@@ -2048,7 +2048,7 @@
         "syntax": "normal | italic | oblique"
       },
       "font-weight": {
-        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
+        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
       },
       "font-stretch": {
         "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded"
@@ -2119,7 +2119,7 @@
         "syntax": "normal | italic | oblique"
       },
       "font-weight": {
-        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
+        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
       },
       "font-stretch": {
         "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded"
@@ -2312,7 +2312,7 @@
         "comment": "Deprecated in 1.1. Please use 'font-style' on the 'title' child element"
       },
       "font-weight": {
-        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900",
+        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900",
         "comment": "Deprecated in 1.1. Please use 'font-weight' on the 'title' child element"
       },
       "font-stretch": {
@@ -2382,7 +2382,7 @@
         "syntax": "normal | italic | oblique"
       },
       "font-weight": {
-        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
+        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
       },
       "font-stretch": {
         "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded"
@@ -2791,7 +2791,7 @@
         "syntax": "normal | italic | oblique"
       },
       "font-weight": {
-        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
+        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
       },
       "font-stretch": {
         "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded"
@@ -3975,7 +3975,7 @@
         "syntax": "normal | italic | oblique"
       },
       "font-weight": {
-        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
+        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
       },
       "font-stretch": {
         "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded"
@@ -6796,7 +6796,7 @@
         "syntax": "normal | italic | oblique"
       },
       "font-weight": {
-        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
+        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
       },
       "font-stretch": {
         "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded"
@@ -6871,7 +6871,7 @@
         "syntax": "normal | italic | oblique"
       },
       "font-weight": {
-        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
+        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
       },
       "font-stretch": {
         "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded"
@@ -7234,7 +7234,7 @@
         "syntax": "normal | italic | oblique"
       },
       "font-weight": {
-        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
+        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
       },
       "font-stretch": {
         "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded"
@@ -7311,7 +7311,7 @@
         "syntax": "normal | italic | oblique"
       },
       "font-weight": {
-        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
+        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
       },
       "font-stretch": {
         "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded"
@@ -7343,7 +7343,7 @@
         "syntax": "normal | italic | oblique"
       },
       "font-weight": {
-        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
+        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
       },
       "font-stretch": {
         "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded"
@@ -7519,7 +7519,7 @@
         "syntax": "normal | italic | oblique"
       },
       "font-weight": {
-        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
+        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
       },
       "font-stretch": {
         "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded"
@@ -7590,7 +7590,7 @@
         "syntax": "normal | italic | oblique"
       },
       "font-weight": {
-        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
+        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
       },
       "font-stretch": {
         "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded"
@@ -7940,7 +7940,7 @@
         "syntax": "normal | italic | oblique"
       },
       "font-weight": {
-        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
+        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
       },
       "font-stretch": {
         "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded"
@@ -8477,7 +8477,7 @@
         "syntax": "normal | italic | oblique"
       },
       "font-weight": {
-        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
+        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
       },
       "font-stretch": {
         "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded"
@@ -8913,7 +8913,7 @@
         "syntax": "normal | italic | oblique"
       },
       "font-weight": {
-        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
+        "syntax": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900"
       },
       "font-stretch": {
         "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded"

--- a/docs/src/specs/documentation.json
+++ b/docs/src/specs/documentation.json
@@ -121,7 +121,7 @@
           }
         },
         "font-weight": {
-          "source": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900",
+          "source": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900",
           "ast": {
             "xor": [
               {
@@ -558,7 +558,7 @@
           }
         },
         "font-weight": {
-          "source": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900",
+          "source": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900",
           "ast": {
             "xor": [
               {
@@ -1440,7 +1440,7 @@
           "comment": "Deprecated in 1.1. Please use 'font-style' on the 'title' child element"
         },
         "font-weight": {
-          "source": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900",
+          "source": "normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900",
           "ast": {
             "xor": [
               {

--- a/src/Core/Styling/Fonts/PXFontEntry.m
+++ b/src/Core/Styling/Fonts/PXFontEntry.m
@@ -63,10 +63,13 @@ static NSRegularExpression *DIGIT_WEIGHT;
             @"medium" : @(500),
             @"normal" : @(400),
             @"light" : @(300),
-            @"extra-thin" : @(200),
-            @"ultra-thin" : @(200),
+            @"xlight" : @(200),
+            @"extra-light" : @(200),
             @"ultra-light" : @(200),
             @"thin" : @(100),
+            @"xthin" : @(100),
+            @"extra-thin" : @(100),
+            @"ultra-thin" : @(100),
         };
     }
 
@@ -402,17 +405,14 @@ static NSRegularExpression *DIGIT_WEIGHT;
             result = 500;
         }
         // NOTE: "normal" is the default below
-        else if ([name rangeOfString:@"light"].location != NSNotFound && [name rangeOfString:@"ultralight"].location == NSNotFound)
-        {
-            result = 300;
-        }
-        else if (
-                [name rangeOfString:@"extrathin"].location != NSNotFound
-            ||  [name rangeOfString:@"ultrathin"].location != NSNotFound
-            ||  [name rangeOfString:@"ultralight"].location != NSNotFound)
+        else if ([name rangeOfString:@"xlight"].location != NSNotFound || [name rangeOfString:@"ultralight"].location != NSNotFound)
         {
             result = 200;
         }
+        else if ([name rangeOfString:@"light"].location != NSNotFound)
+        {
+            result = 300;
+        } 
         else if ([name rangeOfString:@"thin"].location != NSNotFound)
         {
             result = 100;

--- a/src/Core/Styling/Stylers/PXAttributedTextStyler.h
+++ b/src/Core/Styling/Stylers/PXAttributedTextStyler.h
@@ -30,7 +30,7 @@
  *  - font-family: <string>
  *  - font-size: <length>
  *  - font-style: normal | italic | oblique
- *  - font-weight: normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900
+ *  - font-weight: normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900
  *  - font-stretch: normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded
  *  - letter-spacing: <length> | ems | percent
  *  - text-transform: uppercase | lowercase | capitalize

--- a/src/Core/Styling/Stylers/PXFontStyler.h
+++ b/src/Core/Styling/Stylers/PXFontStyler.h
@@ -29,7 +29,7 @@
  *  - font-family: <string>
  *  - font-size: <length>
  *  - font-style: normal | italic | oblique
- *  - font-weight: normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900
+ *  - font-weight: normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900
  *  - font-stretch: normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded
  */
 

--- a/src/Modules/UIModule/Controls/PXUINavigationBar.h
+++ b/src/Modules/UIModule/Controls/PXUINavigationBar.h
@@ -53,7 +53,7 @@
  *  - font-family: <string> // Deprecated in 1.1. Please use 'font-family' on the 'title' child element
  *  - font-size: <length> // Deprecated in 1.1. Please use 'font-size' on the 'title' child element
  *  - font-style: normal | italic | oblique // Deprecated in 1.1. Please use 'font-style' on the 'title' child element
- *  - font-weight: normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 // Deprecated in 1.1. Please use 'font-weight' on the 'title' child element
+ *  - font-weight: normal | bold | black | heavy | extra-bold | ultra-bold | semi-bold | demi-bold | medium | light | extra-light | ultra-light | extra-thin | ultra-thin | thin | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 // Deprecated in 1.1. Please use 'font-weight' on the 'title' child element
  *  - font-stretch: normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded // Deprecated in 1.1. Please use 'font-stretch' on the 'title' child element
  *  - PXTextContentStyler
  *  - text-transform: lowercase | uppercase | capitalize


### PR DESCRIPTION
- Add specific support for Gotham XLight
- Reassign previous weight names to their correct value. For instance, Thin or lighter should just be 100.
